### PR TITLE
Display records from Western Pennsylvania Regional Data Center as map makers 

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,8 +7,6 @@
         attribution: '&amp;copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
     }).addTo(map);
 
-    L.marker([40.4365, -79.9524]).addTo(map);
-
     const sqlQuery = 'SELECT * FROM "40776043-ad00-40f5-9dc8-1fde865ff571" WHERE "NEIGHBORHOOD" LIKE \'%Oakland\'';
     fetch(`https://data.wprdc.org/api/action/datastore_search_sql?sql=${sqlQuery}`).then((res) => {
       // TODO: check for 200 response

--- a/main.js
+++ b/main.js
@@ -7,4 +7,24 @@
         attribution: '&amp;copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
     }).addTo(map);
 
+    L.marker([40.4365, -79.9524]).addTo(map);
+
+    const sqlQuery = 'SELECT * FROM "40776043-ad00-40f5-9dc8-1fde865ff571" WHERE "NEIGHBORHOOD" LIKE \'%Oakland\'';
+    fetch(`https://data.wprdc.org/api/action/datastore_search_sql?sql=${sqlQuery}`).then((res) => {
+      // TODO: check for 200 response
+      console.log(res);
+      return res.json();
+    }).then((jsonRes) => {
+      console.log(jsonRes);
+      for (const record of jsonRes.result.records) {
+        console.log(record);
+        const marker = L.marker([record.Y, record.X], {
+          title: record.REQUEST_TYPE || 'default title',
+          zIndexOffset: 100
+        });
+        marker.bindPopup(`<pre>${JSON.stringify(record, null, 2)}</pre>`);
+        marker.addTo(map);
+      }
+    });
+
 })(typeof window !== "undefined" ? window : {});

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@
         attribution: '&amp;copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
     }).addTo(map);
 
-    const sqlQuery = 'SELECT * FROM "40776043-ad00-40f5-9dc8-1fde865ff571" WHERE "NEIGHBORHOOD" LIKE \'%Oakland\'';
+    const sqlQuery = 'SELECT * FROM "40776043-ad00-40f5-9dc8-1fde865ff571" WHERE "NEIGHBORHOOD" LIKE \'%Oakland\' LIMIT 25';
     fetch(`https://data.wprdc.org/api/action/datastore_search_sql?sql=${sqlQuery}`).then((res) => {
       // TODO: check for 200 response
       console.log(res);


### PR DESCRIPTION
This PR adds fetching Oakland-related records from the 311 dataset on WPRDC and displays them as map markers.

This does not handle errors when a request fails and does not retry the request. An invalid response will also not be handled correctly as well.