### PR TITLE
Update the ordering of the logic statements to pull Lat Long positions after filtering

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,9 +330,6 @@
                         dataSource.processRecord(record, i);
                     }
 
-                    const latLong = dataSource.latLong.map((fieldName) => record[fieldName]);
-                    const latLongNoNulls = latLong.some((field) => !!field);
-
                     //Prune to last 30 days
                     if (record.incidentYear) {
                       if (getDateDifference(currentDate, new Date(record.incidentYear,
@@ -344,6 +341,9 @@
 
                     record.inDate = true;
                     record.type = dataSourceName.toLowerCase();
+
+                    const latLong = dataSource.latLong.map((fieldName) => record[fieldName]);
+                    const latLongNoNulls = latLong.some((field) => !!field);
 
                     if (latLongNoNulls) {
                         const title = dataSource.title(record);


### PR DESCRIPTION
Filtering should be done after processing, but before fetching the latitude and longitude for the sake of consistency and grouping the variable declarations and the logic statements together.