### PR TITLE
Only filter mapped pins to prevent null object exceptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,7 +97,7 @@
 
         if (elm.checked) {
             markers.forEach((marker) => {
-                if (marker.type === type) {
+                if (marker.type === type && marker.isMapped) {
                     if (marker.inDate) {
                         marker.pin.addTo(map);
                     }
@@ -106,7 +106,7 @@
             });
         } else {
             markers.forEach((marker) => {
-                if (marker.type === type) {
+                if (marker.type === type && marker.isMapped) {
                     map.removeLayer(marker.pin);
                     marker.filtered = true;
                 }


### PR DESCRIPTION
The `filterDisplay` function would error out when deselecting the Police WPRDC data because of entries that are not mapped and have `isMapped === false`. This just prevents the `filterDisplay` function from modifying those records in the `markers` array.