### PR TITLE
Notifications of errors with requests and retrying requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -349,10 +349,17 @@
         }
 
         return fetch(WPRDC_BASE_URL + query)
-            // TODO: ensure 200 response
+            .then((response) => {
+              // Inspired by https://github.com/github/fetch#handling-http-error-statuses
+              if (response.status >= 200 && response.status < 300) {
+                return response;
+              } else {
+                const error = new Error(response.errorText);
+                error.response = response;
+                displayNotification(error, "error response");
+              }
+            })
             .then((response) => response.json())
-            // TODO: should have some generic error handling for data
-            .catch((err) => displayNotification(err, "error"))
             .then((data) => {
                 const records = data.result.records;
 
@@ -411,7 +418,8 @@
                     }
                     markers.push(record);
                 })
-            });
+            })
+            .catch((err) => displayNotification(err, "error after record process"));
     }
 
     Promise.all([
@@ -425,6 +433,7 @@
         console.log('All data loaded');
     }).catch((err) => {
         console.log('final error catch data', err);
+        displayNotification(err, "error total");
     });
 
     //Helper function that returns difference between two dates in days


### PR DESCRIPTION
I am trying to utilize the recently merged #94 to handle when notification to the user that an error occurred while trying to retrieve data from the various data sources. This allows for the user to either re-request the data from the data source or just ignore it. Right now it just displays the errors in the three places that error handling occurs.

Looking for feedback and ways to move this forward.