### PR TITLE
Resolve Issue 95: Added SQL to prune 311 data to most recent 30 days

### DIFF
--- a/data.js
+++ b/data.js
@@ -111,7 +111,7 @@
         // TODO: would be great to prune 311 data to the last 30 days, like the police data
         "311": {
             id: "40776043-ad00-40f5-9dc8-1fde865ff571",
-            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' ORDER BY \"CREATED_ON\" DESC",
+            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"CREATED_ON\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CREATED_ON\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_311_ICON,
 

--- a/data.js
+++ b/data.js
@@ -53,7 +53,7 @@
     const WPRDC_DATA_SOURCES = {
         "Police": {
             id: "1797ead8-8262-41cc-9099-cbc8a161924b",
-            primaryFiltering: "WHERE \"INCIDENTNEIGHBORHOOD\" LIKE '%Oakland'",
+            primaryFiltering: "WHERE \"INCIDENTNEIGHBORHOOD\" LIKE '%Oakland' AND \"INCIDENTTIME\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"INCIDENTTIME\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_POLICE,
 
@@ -71,7 +71,7 @@
 
         "Arrest": {
             id: "e03a89dd-134a-4ee8-a2bd-62c40aeebc6f",
-            primaryFiltering: "WHERE \"INCIDENTNEIGHBORHOOD\" LIKE '%Oakland'",
+            primaryFiltering: "WHERE \"INCIDENTNEIGHBORHOOD\" LIKE '%Oakland' AND \"ARRESTTIME\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"ARRESTTIME\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_ARREST,
 
@@ -89,7 +89,7 @@
 
         "Code Violation": {
             id: "4e5374be-1a88-47f7-afee-6a79317019b4",
-            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland'",
+            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"INSPECTION_DATE\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"INSPECTION_DATE\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CODE_VIOLATION,
 
@@ -131,7 +131,7 @@
         // Calls from the library db
         "Library": {
             id: "2ba0788a-2f35-43aa-a47c-89c75f55cf9d",
-            primaryFiltering: "WHERE \"Name\" LIKE '%OAKLAND%'",
+            primaryFiltering: "WHERE \"Name\" LIKE '%OAKLAND%' AND \"CITEDTIME\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CITEDTIME\" DESC",
             latLong: ["Lat", "Lon"],
             icon: iconTypes.LIBRARY_ICON,
 

--- a/data.js
+++ b/data.js
@@ -130,7 +130,7 @@
         // Calls from the library db
         "Library": {
             id: "2ba0788a-2f35-43aa-a47c-89c75f55cf9d",
-            primaryFiltering: "WHERE \"Name\" LIKE '%OAKLAND%' AND \"CITEDTIME\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CITEDTIME\" DESC",
+            primaryFiltering: "WHERE \"Name\" LIKE '%OAKLAND%'",
             latLong: ["Lat", "Lon"],
             icon: iconTypes.LIBRARY_ICON,
 

--- a/data.js
+++ b/data.js
@@ -108,7 +108,6 @@
         },
 
         // City of Pittsburgh 311 data
-        // TODO: would be great to prune 311 data to the last 30 days, like the police data
         "311": {
             id: "40776043-ad00-40f5-9dc8-1fde865ff571",
             primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"CREATED_ON\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CREATED_ON\" DESC",

--- a/main.js
+++ b/main.js
@@ -286,7 +286,7 @@
         // TODO: would be great to prune 311 data to the last 30 days, like the police data
         "311": {
             id: "40776043-ad00-40f5-9dc8-1fde865ff571",
-            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' ORDER BY \"CREATED_ON\" DESC",
+            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"CREATED_ON\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CREATED_ON\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_311_ICON,
 
@@ -455,7 +455,7 @@
     function fetchAllData() {
         Promise.all([
             fetchWPRDCData("Police", { limit: 250 }),
-            fetchWPRDCData("311", { limit: 250 }),
+            fetchWPRDCData("311"),
             fetchWPRDCData("Arrest", { limit: 250 }),
             fetchWPRDCData("Code Violation", { limit: 250 }),
             fetchWPRDCData("Library"),

--- a/main.js
+++ b/main.js
@@ -286,7 +286,7 @@
         // TODO: would be great to prune 311 data to the last 30 days, like the police data
         "311": {
             id: "40776043-ad00-40f5-9dc8-1fde865ff571",
-            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"CREATED_ON\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CREATED_ON\" DESC",
+            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' ORDER BY \"CREATED_ON\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_311_ICON,
 
@@ -455,7 +455,7 @@
     function fetchAllData() {
         Promise.all([
             fetchWPRDCData("Police", { limit: 250 }),
-            fetchWPRDCData("311"),
+            fetchWPRDCData("311", { limit: 250 }),
             fetchWPRDCData("Arrest", { limit: 250 }),
             fetchWPRDCData("Code Violation", { limit: 250 }),
             fetchWPRDCData("Library"),

--- a/main.js
+++ b/main.js
@@ -201,7 +201,6 @@
     // data was here
 
     // Fetch data from West Pennsylvania Regional Data Center using the SQL API
-    // TODO: Prune to last 30 days in SQL
     function fetchWPRDCData(dataSourceName, options={}) {
         const dataSource = WPRDC_DATA_SOURCES[dataSourceName];
         let query = WPRDC_QUERY_PREFIX + dataSource.id + WPRDC_QUERY_SUFFIX + dataSource.primaryFiltering;


### PR DESCRIPTION
Updated the SQL query for gathering 311 data, to limit the data returned
to be from the most recent 30 days.

Also removed the arbitrary limitation that had been on the 311 data,
which limited it to gather the 250 most recent records.