### PR TITLE
Adjusted button positioning and animated notifications

### DIFF
--- a/main.css
+++ b/main.css
@@ -69,6 +69,22 @@ html, body
     cursor: pointer;
 }
 
+@keyFrames vanish
+{
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+.vanish
+{
+    animation-duration: 1s;
+    animation-name: vanish;
+}
+
 .retry
 {
     position: relative;
@@ -304,9 +320,14 @@ html, body
     padding: 5px;
 }
 
-#dateSelection
+#dateSelection, #displaySelection
 {
     display: flex;
+}
+
+#dateSelection
+{
+    margin-top: 5px;
 }
 
 button
@@ -316,11 +337,6 @@ button
     border: 1px solid lightgrey;
     margin-left: -1px;
     padding: 5px 5px;
-}
-
-#dateSelection:first-child
-{
-    margin-left: 1px;
 }
 
 button:hover

--- a/main.css
+++ b/main.css
@@ -69,6 +69,22 @@ html, body
     cursor: pointer;
 }
 
+@keyFrames vanish
+{
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+.vanish
+{
+    animation-duration: 1s;
+    animation-name: vanish;
+}
+
 .retry
 {
     position: relative;

--- a/main.css
+++ b/main.css
@@ -69,22 +69,6 @@ html, body
     cursor: pointer;
 }
 
-@keyFrames vanish
-{
-    0% {
-        opacity: 1;
-    }
-    100% {
-        opacity: 0;
-    }
-}
-
-.vanish
-{
-    animation-duration: 1s;
-    animation-name: vanish;
-}
-
 .retry
 {
     position: relative;

--- a/map.js
+++ b/map.js
@@ -268,7 +268,7 @@
         closeButton.className = "close";
         closeButton.innerHTML = "x";
         closeButton.addEventListener("click", function() {
-            box.style.display = "none";
+            vanish();
         });
 
         box.appendChild(closeButton);
@@ -281,6 +281,17 @@
             customHTML(customDiv);
             box.appendChild(customDiv);
         }
+
+        function vanish() {
+            box.classList.add("vanish");
+            setTimeout(function() {
+                if (box.classList.contains("vanish")) {
+                    box.style.display = "none";
+                }
+            }, 1000);
+        }
+
+        setTimeout(vanish, 7000);
 
         const topNotification = notificationArea.firstChild;
         notificationArea.insertBefore(box, topNotification);


### PR DESCRIPTION
I noticed the "Map" and "Data" buttons were separated, contrasting with the buttons below. I modified the css a little to fix this, and also added some spacing between the button groups to prettify it.

In addition, I (accidentally) committed a notification animation, in which they become transparent one second after clicking the close button. Also, I made it so the notifications do so on their own after seven seconds, but I'd be happy to take this out should it be an issue.