### PR TITLE
Added Customization for Organizations through Checkboxes and Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ to the `head` tag, as well as
 ```
 somewhere in the `body`.
 
+In order to turn on or off default checkboxes, open up `map.js`, CTRL+F 'DEFAULT_CHECKS', and change a value to `false` to turn it off by default and `true` to turn it on by default.
+
 ## Getting started:
 1. Fork the project
 2. Add your name to `contributors.md`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ somewhere in the `body`.
 
 In order to turn on or off default checkboxes, open up `map.js`, CTRL+F 'DEFAULT_CHECKS', and change a value to `false` to turn it off by default and `true` to turn it on by default.
 
+In order to change the default view (currently shipped with weekly data as default) to the past month, week, or day, open `map.js`, CTRL+F 'DEFAULT_VIEW', and read the documentation.  You can change the value to "month", "week", or "day"; anything else will default to weekly data.
+
 ## Getting started:
 1. Fork the project
 2. Add your name to `contributors.md`

--- a/about.html
+++ b/about.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PantherView</title>
+    <meta name="description" content="Map for Oakland data.">
+    <link rel="icon" href="favicon.ico" />
+    <!--favicons-->
+    <link rel="apple-touch-icon" sizes="57x57" href="./favicons/apple-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="./favicons/apple-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="./favicons/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="./favicons/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="./favicons/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="./favicons/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="./favicons/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="./favicons/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="./favicons/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="192x192"  href="./favicons/android-icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="./favicons/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./favicons/favicon-16x16.png">
+    <link rel="manifest" href="./favicons/manifest.json">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="./favicons/ms-icon-144x144.png">
+    <meta name="theme-color" content="#ffffff">
+
+  </head>
+
+  <body>
+    <h1>Contributors</h1><hr/>
+    <p>JJ Naughton</p>
+    <p>John Linahan - <b>CSC President</b></p>
+    <p>Alexis John Aquiatan</p>
+    <p>Matt Bilker <a href="me@mbilker.us">me@mbilker.us</a></p>
+    <p>Chandler Yocca</p>
+    <p>Kai Dawkins</p>
+    <p>Simon Cao</p>
+    <p>Matthew Duing</p>
+    <p>Daniel Zheng - <b>CSC Business Manager</b></p>
+    <p>Chris Seifried</p>
+    <p>Colton Blake</p>
+    <p>Austin Marcus</p>
+    <p>Sriram Iyer</p>
+    <p>Sai Xu</p>
+    <p>Benjamin Lodi</p>
+    <p>Jeffrey Willis</p>
+    <p>Chris Skowronski</p>
+    <p>Brandon Palonis</p>
+    <p>Neha Abraham</p>
+    <p>Sam Nigh - <b>CSC Events Coordinator</b></p>
+    <p>Franklin Ty</p>
+    <p>Kyle Amoroso</p>
+    <p>Benjamin Muscato</p>
+    <p>James Hahn - <b>CSC Vice-President</b></p><hr/>
+
+    <h1>University of Pittsburgh Computer Science Club (Pitt CSC)</h1><hr/>
+    <p>...Insert description of the club and what we do here...</p>
+    <hr/>
+
+    <h1>About this Project</h1><hr/>
+    <p>...Insert description of this project, its motivation, where we plan to take it, who can contribute, what it adds, where it pulls data from...</p>
+    <hr/>
+  </body>
+
+</html>

--- a/contributors.md
+++ b/contributors.md
@@ -45,3 +45,5 @@ Franklin Ty
 Kyle Amoroso
 
 Benjamin Muscato
+
+James Hahn

--- a/map.js
+++ b/map.js
@@ -8,7 +8,8 @@
         WPRDC_QUERY_PREFIX,
         WPRDC_QUERY_SUFFIX,
         PITT_LAUNDRY,
-        PITT_LABS;
+        PITT_LABS,
+        DEFAULT_CHECKS;
 
     // await those values
     window.addEventListener("dataready", function handler(event) {
@@ -22,6 +23,10 @@
             PITT_LAUNDRY,
             PITT_LABS
         } = event.detail);
+
+        // select the default checkmarked boxes
+        // true = turned on by default; false = turned off by default
+        DEFAULT_CHECKS = { "library": true, "arrest": true, "police": true, "code violation": true, "non-traffic violation": true, "311": true, "labs": true, "laundry": true };
 
         // wait for these values before fetching dependant data
         fetchAllData();
@@ -330,7 +335,9 @@
                 const filter = document.createElement("input");
                 filter.id = dataSourceName.toLowerCase() + "Check";
                 filter.type = "checkbox";
-                filter.checked = true;
+                if (DEFAULT_CHECKS[dataSourceName.toLowerCase()] == true) {
+                    filter.checked = true;
+                }
                 const filterLabelDec = document.createElement("label");
                 filterLabelDec.htmlFor = dataSourceName.toLowerCase() + "Check";
 
@@ -373,7 +380,12 @@
                         });
 
                         record.pin.bindPopup(dataSource.popup(record));
-                        record.pin.addTo(map);
+
+                        record.filtered = true;
+                        if (filter.checked == true) {
+                            record.pin.addTo(map);
+                            record.filtered = false;
+                        }
 
                         record.isMapped = true;
                     } else {
@@ -472,7 +484,9 @@
                 var filter = document.createElement("input");
                 filter.id = dataSection.toLowerCase() + "Check";
                 filter.type = "checkbox";
-                filter.checked = true;
+                if (DEFAULT_CHECKS[dataSection.toLowerCase()] == true) {
+                    filter.checked = true;
+                }
                 var filterLabelDec = document.createElement("label");
                 filterLabelDec.htmlFor = dataSection.toLowerCase() + "Check";
 
@@ -519,8 +533,11 @@
                 //labRecord.popup = pup;
                 //Bind popup to pin
                 thePin.bindPopup(pup);
-                //Add pin to map
-                thePin.addTo(map);
+                //Add pin to map if Labs checkbox is ticked
+                var filter = document.getElementById("labsCheck");
+                if (filter.checked == true) {
+                    thePin.addTo(map);
+                }
                 pup.isMapped = true;
                 //Push pin (haha, get it?)
                 markers.push({ //Push the following object onto the markers array
@@ -565,7 +582,10 @@
                 //Bind popup to pin
                 thePin.bindPopup(pup);
                 //Add pin to map
-                thePin.addTo(map);
+                var filter = document.getElementById("laundryCheck");
+                if (filter.checked == true) {
+                    thePin.addTo(map);
+                }
                 pup.isMapped = true;
                 //Push pin (haha, get it?)
                 markers.push({ //Push the following object onto the markers array
@@ -591,7 +611,7 @@
                 });
                 retryDiv.appendChild(retryButton);
         }));
-    }//End fetchPittData()
+    }
 
     function fetchAllData() {
         Promise.all([

--- a/map.js
+++ b/map.js
@@ -112,6 +112,7 @@
         document.getElementById("radioDay").style.backgroundColor = "#fff";
         document.getElementById("radioWeek").style.backgroundColor = "lightgrey";
         document.getElementById("radioMonth").style.backrgoundColor = "#fff";
+        document.getElementById("radioMonth").style.backgroundColor = "#fff"; // NOTE: when switching from month to week data, the month button is stuck on "lightgrey" so this statement makes sure it is "#fff" instead
         markers.forEach((marker, i) => {
             if (!marker.incidentYear || !marker.isMapped) {
                 return;

--- a/map.js
+++ b/map.js
@@ -9,7 +9,8 @@
         WPRDC_QUERY_SUFFIX,
         PITT_LAUNDRY,
         PITT_LABS,
-        DEFAULT_CHECKS;
+        DEFAULT_CHECKS,
+        DEFAULT_VIEW;
 
     // await those values
     window.addEventListener("dataready", function handler(event) {
@@ -27,6 +28,12 @@
         // select the default checkmarked boxes
         // true = turned on by default; false = turned off by default
         DEFAULT_CHECKS = { "library": true, "arrest": true, "police": true, "code violation": true, "non-traffic violation": true, "311": true, "labs": true, "laundry": true };
+
+        // choose the default data shown in the map; can hold 1 of 3 strings:
+        // "month" = show data from the previous 30 days
+        // "week"  = show data from the previous 7 days
+        // "day"   = show data from the previous day
+        DEFAULT_VIEW = "week";
 
         // wait for these values before fetching dependant data
         fetchAllData();
@@ -383,7 +390,6 @@
 
                         record.filtered = true;
                         if (filter.checked == true) {
-                            record.pin.addTo(map);
                             record.filtered = false;
                         }
 
@@ -652,8 +658,19 @@
                 retryDiv.appendChild(retryButton);
             });
         }).then(() => {
-            //display past week map as default
-            displayPastWeek();
+            switch (DEFAULT_VIEW) {
+                case "month":
+                    displayPastMonth();
+                    break;
+                case "week":
+                    displayPastWeek();
+                    break;
+                case "day":
+                    displayPastDay();
+                    break;
+                default:
+                    displayPastWeek();
+            }
             displayMapMode();
             generateDataTable();
         });


### PR DESCRIPTION
This was mostly created for The Pitt News as per their request; PantherView is nearly published on their website, they just have a couple more suggestions.  They wanted just the Police checkbox to be ticked by default for their users since that's what their users desire the most.  This can be used for almost any other organization.

In order to change the default checkboxes, go to (currently) line 29 and change a data category (e.g. police) to true in the dictionary.  Inversely, if you want to turn the checkbox off by default, switch this value to false.

Any new data categories will need to be added to this dictionary for organizations to be able to fully customize their default checkboxes.